### PR TITLE
Fixed bug in autocompleter for search terms containing special chars

### DIFF
--- a/contentconnector-changelog/src/changelog/entries/2014/10/5066.RT58553.bugfix
+++ b/contentconnector-changelog/src/changelog/entries/2014/10/5066.RT58553.bugfix
@@ -1,0 +1,3 @@
+When searching the autocompleter for terms with special characters, the query
+was not parsed correctly and no results where shown for many words containing
+special characters like umlaute. 

--- a/contentconnector-lucene-autocomplete/src/test/java/com/gentics/cr/lucene/autocomplete/AutocompleteTest.java
+++ b/contentconnector-lucene-autocomplete/src/test/java/com/gentics/cr/lucene/autocomplete/AutocompleteTest.java
@@ -23,14 +23,21 @@ import com.gentics.cr.configuration.EnvironmentConfiguration;
 import com.gentics.cr.exceptions.CRException;
 import com.gentics.cr.lucene.indexaccessor.IndexAccessor;
 import com.gentics.cr.lucene.indexer.index.LuceneIndexLocation;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 
 public class AutocompleteTest {
 	private static CRConfigUtil autoConfig = null;
 	private static RequestProcessor rp=null;
 	private static LuceneIndexLocation location=null;
-	
+	private static Autocompleter autocompleter = null;
+        
 	@BeforeClass
 	public static void setUp() throws CRException, URISyntaxException, IOException {
+                String configLocation = AutocompleteTest.class.getResource(".").toURI().getPath();
+		EnvironmentConfiguration.setConfigPath(configLocation);
 		EnvironmentConfiguration.loadEnvironmentProperties();
 		autoConfig = new CRConfigStreamLoader("autocomplete", AutocompleteTest.class.getResourceAsStream("autocomplete.properties"));
 		rp = autoConfig.getNewRequestProcessorInstance(1);
@@ -47,10 +54,15 @@ public class AutocompleteTest {
 		addDoc(accessor, "content:potatoe", "category:plants", "contentid:10007.7");
 		addDoc(accessor, "content:flower", "category:plants", "contentid:10007.8");
 		addDoc(accessor, "content:tree", "category:plants", "contentid:10007.9");
+                addDoc(accessor, "content:schön", "category:words", "contentid:10007.10");
+                addDoc(accessor, "content:schon", "category:words", "contentid:10007.11");
+                addDoc(accessor, "content:schon", "category:words", "contentid:10007.12");
+                addDoc(accessor, "content:ignore", "category:words", "contentid:10007.13");
 		
 		AutocompleteIndexExtension autoExtension = new AutocompleteIndexExtension(rpConfig, location);
 		AutocompleteIndexJob aIJ = new AutocompleteIndexJob(autoConfig, location, autoExtension);
 		aIJ.run();
+                autocompleter = new Autocompleter(rpConfig);
 	}
 	
 	@Test
@@ -59,30 +71,90 @@ public class AutocompleteTest {
 	}
 	
 	@Test
-	public void testSingleAutocomplete() throws CRException {
-		CRRequest request = new CRRequest();
-		request.setRequestFilter("a");
-		Collection<CRResolvableBean> objects = rp.getObjects(request);
-		Assert.assertEquals("The Search did not find all items.", 1, objects.size());
-		CRResolvableBean bean = objects.iterator().next();
-		Assert.assertEquals("Autocomplete result did not return the expected word", "audi", bean.get("word"));
-		Assert.assertEquals("Autocomplete result did not return the expected word count", "1", bean.get("count"));
+	public void testSingleAutocomplete() throws CRException, IOException {
+            HashMap<String, Integer> shouldContain = new HashMap<String, Integer>();
+            shouldContain.put("audi", 1);
+
+            Collection<CRResolvableBean> objects = retrieveSuggestions("a");
+            checkResolveableCollection(objects, 1, shouldContain);
 	}
 	
 	@Test
-	public void testMultiAutocomplete() throws CRException {
-		CRRequest request = new CRRequest();
-		request.setRequestFilter("p");
-		Collection<CRResolvableBean> objects = rp.getObjects(request);
-		Assert.assertEquals("The Search did not find all items.", 2, objects.size());
-		CRResolvableBean bean = objects.iterator().next();
-		Assert.assertEquals("Autocomplete result did not return the expected word", true, "potatoe".equals(bean.get("word")) || "pagani".equals(bean.get("word")));
-		Assert.assertEquals("Autocomplete result did not return the expected word count", "1", bean.get("count"));
-		bean = objects.iterator().next();
-		Assert.assertEquals("Autocomplete result did not return the expected word", true, "potatoe".equals(bean.get("word")) || "pagani".equals(bean.get("word")));
-		Assert.assertEquals("Autocomplete result did not return the expected word count", "1", bean.get("count"));
+	public void testMultiAutocomplete() throws CRException, IOException {
+            HashMap<String, Integer> shouldContain = new HashMap<String, Integer>();
+            shouldContain.put("potatoe", 1);
+            shouldContain.put("pagani", 1);
+
+            Collection<CRResolvableBean> objects = retrieveSuggestions("p");
+            checkResolveableCollection(objects, 2, shouldContain);
 	}
-	
+        
+        
+        /**
+         * Tests if the search term is parsed correctly and if words containing
+         * special characters (umlaute) can be found.
+         */
+        @Test
+        public void testSearchTermParsing() throws CRException, IOException {
+            HashMap<String, Integer> shouldContain = new HashMap<String, Integer>();
+            shouldContain.put("schon", 2); // there are 2 documents containing "schon" 
+            shouldContain.put("schön", 1); // there is only 1 documents containing "schön" 
+            
+            // test if words with special characters are found by ASCII equivalent ('o' == 'ö')
+            Collection<CRResolvableBean> suggestedWords = retrieveSuggestions("scho");
+            checkResolveableCollection(suggestedWords, 2, shouldContain);
+            
+            // test if words with special chars are found (including words with the ASCII equivalent of the special char)
+            suggestedWords = retrieveSuggestions("schö");
+            checkResolveableCollection(suggestedWords, 2, shouldContain);
+            
+            // test if only the last word is used for suggestions (ignore is in the index but should not be in the collection)
+            suggestedWords = retrieveSuggestions("ignore scho");
+            checkResolveableCollection(suggestedWords, 2, shouldContain);
+            // check if "ignore" is really in the index
+            suggestedWords = retrieveSuggestions("ignore");
+            shouldContain = new HashMap<String, Integer>();
+            shouldContain.put("ignore", 1);
+            checkResolveableCollection(suggestedWords, 1, shouldContain);
+        }
+        /**
+         * Check a autocomplete resolveable collection for size and the 
+         * suggested words it contains. This method will call assertions for
+         * the collection size, the expected document count for a certain word
+         * and if certain words are contained in the collection
+         * 
+         * @param collection the collection to check
+         * @param size the expected size of the collection
+         * @param shouldContain a hash map of the words this collection should contain (keys) and the expected document count (value)
+         */
+        private void checkResolveableCollection(Collection<CRResolvableBean> collection, int size, HashMap<String, Integer> shouldContain) {
+            Assert.assertEquals("Expected size of collection does not match actual size", size, collection.size());
+            List<String> foundWords = new ArrayList<String>();
+            Iterator<CRResolvableBean> it = collection.iterator();
+            while(it.hasNext()) {
+                CRResolvableBean bean = it.next();
+                String word = (String) bean.get("word");
+                foundWords.add(word);
+                if(shouldContain.get(word) != null) {
+                    StringBuilder sb = new StringBuilder("Autocompleter did not return the expected result count for '");
+                    sb.append(word).append("'");
+                    Integer count = Integer.parseInt((String) bean.get("count"));
+                    Assert.assertEquals(sb.toString(), shouldContain.get(word), count);
+                }
+            }
+            Assert.assertTrue("Not all words the collections should contain where found", foundWords.containsAll(shouldContain.keySet()));
+        }
+        /**
+         * get suggestions for a term
+         * @param term the term to search for
+         * @return the resolveables the autocompleter found for this term
+         * @throws IOException 
+         */
+	private Collection<CRResolvableBean> retrieveSuggestions(String term) throws IOException {
+            CRRequest request = new CRRequest();
+            request.setRequestFilter(term);
+            return autocompleter.suggestWords(request);
+        }
 	/**
 	 * Adds a Document to the index.
 	 * @param ia

--- a/contentconnector-lucene-autocomplete/src/test/resources/com/gentics/cr/lucene/autocomplete/autocomplete.properties
+++ b/contentconnector-lucene-autocomplete/src/test/resources/com/gentics/cr/lucene/autocomplete/autocomplete.properties
@@ -9,7 +9,7 @@ rp.1.useAutocompleteIndexer=true
 rp.1.rpClass=com.gentics.cr.lucene.autocomplete.AutocompleteRequestProcessor
 rp.1.autocompletelocation.indexLocationClass=com.gentics.cr.lucene.indexer.index.LuceneSingleIndexLocation
 rp.1.autocompletelocation.indexLocations.0.path=RAM_AUTOCOMPLETE
-rp.1.autocompletelocation.analyzerconfig=${com.gentics.portalnode.confpath}/rest/autocompleteanalyzer.properties
+rp.1.autocompletelocation.analyzerconfig=${com.gentics.portalnode.confpath}/autocompleteanalyzer.properties
 rp.1.autocompletelocation.reopencheck=timestamp
 # the configuration properties for the source index location (srcindexlocation) are not needed 
 # when useAutocompleteIndexer == true

--- a/contentconnector-lucene-autocomplete/src/test/resources/com/gentics/cr/lucene/autocomplete/autocompleteanalyzer.properties
+++ b/contentconnector-lucene-autocomplete/src/test/resources/com/gentics/cr/lucene/autocomplete/autocompleteanalyzer.properties
@@ -1,0 +1,6 @@
+#=================================================================================================
+# Lucence autocomplete analyzer configuration file
+#=================================================================================================
+
+content.analyzerclass=com.gentics.cr.lucene.autocomplete.AutocompleteAnalyzer
+content.fieldname=grammedwords

--- a/contentconnector-lucene-autocomplete/src/test/resources/com/gentics/cr/lucene/autocomplete/nodelog.properties
+++ b/contentconnector-lucene-autocomplete/src/test/resources/com/gentics/cr/lucene/autocomplete/nodelog.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=ERROR, A1
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n


### PR DESCRIPTION
When searching the autocompleter for terms with special characters, the query
was not parsed correctly and no results where shown for many words containing
special characters like umlaute. 
See RT-Ticket 58553 https://support.gentics.com/Ticket/Display.html?id=58553
