### PR TITLE
Hotfix 2.0.x sup 1556

### DIFF
--- a/contentconnector-changelog/src/changelog/entries/2015/09/5437.bugfix
+++ b/contentconnector-changelog/src/changelog/entries/2015/09/5437.bugfix
@@ -1,0 +1,4 @@
+Search queries containing the characters '&', '|' or '~' returned unexpected results when
+using the CRQueryParser and inherited classes because those characters where always 
+replaced with 'AND', 'OR' and 'NOT'. This has been fixed: if those characters are 
+escaped (using backslash '\') they won't be replaced anymore.

--- a/contentconnector-lucene/src/main/java/com/gentics/cr/lucene/search/query/CRQueryParser.java
+++ b/contentconnector-lucene/src/main/java/com/gentics/cr/lucene/search/query/CRQueryParser.java
@@ -219,12 +219,18 @@ public class CRQueryParser extends QueryParser {
 
 	/**
 	 * Helper method to replace search parameters from boolean mnoGoSearch query
-	 * into their lucene compatible parameters.
+	 * into their lucene compatible parameters. 
+	 * <p>This method will replace <br>
+	 * '&' with ' AND ' <br>
+	 * '|' with ' OR ' <br>
+	 * '~' with ' NOT ' <br>
+	 * but leave escaped characters (using backslash '\') untouched
+	 * 
 	 * @param mnoGoSearchQuery query with mnoGoSearch Syntax in it.
 	 * @return query with mnoGoSearch syntax replaced for lucene
 	 */
 	protected String replaceBooleanMnoGoSearchQuery(final String mnoGoSearchQuery) {
-		String luceneQuery = mnoGoSearchQuery.replaceAll(" ?\\| ?", " OR ").replaceAll(" ?& ?", " AND ").replace('\'', '"');
+		String luceneQuery = mnoGoSearchQuery.replaceAll("(^|([^\\\\\\s]{1})|\\s)\\| ?", "$2 OR ").replaceAll("(^|([^\\\\\\s]{1})|\\s)& ?", "$2 AND ").replace('\'', '"');
 		luceneQuery = luceneQuery.replaceAll(" ~([a-zA-Z0-9üöäÜÖÄß]+)", " NOT $1");
 		return luceneQuery;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,9 @@
 							<goal>jar</goal>
 							<goal>javadoc</goal>
 						</goals>
+                                                <configuration>
+                                                    <additionalparam>-Xdoclint:none</additionalparam>
+                                                </configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Search queries containing the characters '&', '|' or '~' returned unexpected results when
using the CRQueryParser and inherited classes because those characters where always 
replaced with 'AND', 'OR' and 'NOT'. This has been fixed: if those characters are 
escaped (using backslash '\') they won't be replaced anymore.