### PR TITLE
Update content.properties

### DIFF
--- a/contentconnector-config-sample/src/main/config/rest/content.properties
+++ b/contentconnector-config-sample/src/main/config/rest/content.properties
@@ -9,3 +9,6 @@ rp.1.ds.cache.foreignlinkattributes=true
 rp.1.ds.cache.syncchecking=true
 #RequestProcessor
 rp.1.plinktemplate=content?contentid=$plink.contentid
+# Disable/Enable CRContent cache
+# When enabled, this cache causes issues when used in combination with other caches
+rp.1.crcontentcache=false


### PR DESCRIPTION
Disable crcontent cache in sample configuration.
When enabled, this cache causes issues when used in combination with other caches