### PR TITLE
Fix invalid character error when inserting facets list into xml-response

### DIFF
--- a/contentconnector-changelog/src/changelog/entries/2015/10/5504.bugfix
+++ b/contentconnector-changelog/src/changelog/entries/2015/10/5504.bugfix
@@ -1,0 +1,2 @@
+When fetching search results containing facets and using the XmlContentRepository (type=xml) an error was thrown
+because the facets results where not parsed correctly to the XML-Response. This has been fixed.

--- a/contentconnector-core/src/main/java/com/gentics/cr/rest/xml/XmlContentRepository.java
+++ b/contentconnector-core/src/main/java/com/gentics/cr/rest/xml/XmlContentRepository.java
@@ -19,6 +19,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.json.JSONObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -41,6 +42,17 @@ public class XmlContentRepository extends ContentRepository {
 	 * Serial id.
 	 */
 	private static final long serialVersionUID = -6929053170765114770L;
+
+
+	/**
+	 * Facets List key.
+	 */
+	public static final String FACETS_LIST_KEY = "facetsList";
+
+	/**
+	 * Binary content key.
+	 */
+	public static final String BINARY_CONTENT_KEY = "binarycontent";
 
 	/**
 	 * the root element in the xml code.
@@ -234,7 +246,7 @@ public class XmlContentRepository extends ContentRepository {
 					Object bValue = crBean.getAttrMap().get(entry);
 					String value = "";
 					if (bValue != null) {
-						if (!entry.equals("binarycontent") && (bValue.getClass().isArray() || bValue.getClass() == ArrayList.class)) {
+						if (!BINARY_CONTENT_KEY.equals(entry) && (bValue.getClass().isArray() || bValue.getClass() == ArrayList.class)) {
 							Object[] arr;
 							if (bValue.getClass() == ArrayList.class) {
 								arr = ((ArrayList<Object>) bValue).toArray();
@@ -301,7 +313,7 @@ public class XmlContentRepository extends ContentRepository {
 	 */
 	private void valueToNode(final Document d, final Element attrElement, final String entry, final Object bValue) {
 		String value = "";
-		if (entry.equals("binarycontent")) {
+		if (BINARY_CONTENT_KEY.equals(entry)) {
 			try {
 				value = new String((byte[]) bValue);
 			} catch (ClassCastException x) {
@@ -315,6 +327,13 @@ public class XmlContentRepository extends ContentRepository {
 		} else {
 			if (bValue instanceof String) {
 				value = (String) bValue;
+			} else if (FACETS_LIST_KEY.equals(entry) && bValue instanceof Map<?, ?>) {
+				/*
+				 * Facets lists need special treatment because the keys of the list are numeric values which cannot be
+				 * converted to XML-elements. Therefore currently the facets list is converted to a JSONObject and
+				 * stored in the the CDATA section of the element.
+				 */
+				value = (new JSONObject((Map<?, ?>) bValue)).toString();
 			} else if (bValue instanceof Map<?, ?>) {
 				Map<?, ?> map = (Map<?, ?>) bValue;
 				for (Entry<?, ?> e : map.entrySet()) {

--- a/contentconnector-core/src/test/java/com/gentics/cr/rest/xml/XmlContentRepositoryTest.java
+++ b/contentconnector-core/src/test/java/com/gentics/cr/rest/xml/XmlContentRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.gentics.cr.rest.xml;
+
+import com.gentics.cr.CRResolvableBean;
+import org.json.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import static  org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class XmlContentRepositoryTest {
+    private static final String FACETS_KEY_NUMERIC = "0";
+    private static final String FACETS_VALUE = "something";
+    /**
+     * Test if the XMLContentRepository is able to handle facets lists in resolvables. Facets lists need special treatment
+     * because the keys of the list are numeric values which cannot be converted to XML-elements. Therefore currently
+     * the facets list is converted to a JSONObject and stored in the the CDATA section of the element.
+     * @throws Exception
+     */
+    @Test
+    public void facetsListOutputTest() throws Exception {
+        // Initialize an empty xml cr
+        XmlContentRepository xmlCr = new XmlContentRepository(new String[]{});
+        // add the facets test resolvable to the cr
+        xmlCr.addObject(new TestFacetsResolvable());
+        OutputStream out = new ByteArrayOutputStream();
+        xmlCr.toStream(out);
+        // parse the result as xml using jsoup
+        Document doc = Jsoup.parse(out.toString());
+        Elements facetElements = doc.getElementsByTag(XmlContentRepository.FACETS_LIST_KEY);
+        assertEquals("The result should contain only one facetsList element", facetElements.size(), 1);
+        JSONObject json = new JSONObject(facetElements.first().text());
+        assertEquals("After parsing the contents of the element to JSON the result should be the same as in the original resolvable", json.get(FACETS_KEY_NUMERIC), FACETS_VALUE);
+    }
+
+    class TestFacetsResolvable extends  CRResolvableBean {
+        public TestFacetsResolvable() {
+            super();
+            // Add a map to the resolvable which resembles an basic facets list
+            // e.g. numeric strings as keys
+            Map<String, Object> facetsResultNode = new HashMap<>();
+            facetsResultNode.put(FACETS_KEY_NUMERIC, FACETS_VALUE);
+            set(XmlContentRepository.FACETS_LIST_KEY, facetsResultNode);
+        }
+    }
+}


### PR DESCRIPTION
When fetching search results containing facets and using the XmlContentRepository (type=xml) an error was thrown because the facets results where not parsed correctly to the XML-Response. This has been fixed.
