### PR TITLE
replace all wildcard characters (*) in searchQuery

### DIFF
--- a/contentconnector-changelog/src/changelog/entries/2016/08/5762.bugfix
+++ b/contentconnector-changelog/src/changelog/entries/2016/08/5762.bugfix
@@ -1,0 +1,1 @@
+When using DidYouMean Suggestions and Wildcard-Queries (e.g. *searchTerm*) not all wildcard characters are replace correctly.

--- a/contentconnector-lucene/src/main/java/com/gentics/cr/lucene/search/CRSearcher.java
+++ b/contentconnector-lucene/src/main/java/com/gentics/cr/lucene/search/CRSearcher.java
@@ -599,7 +599,7 @@ public class CRSearcher {
 			Map<Term, Term[]> suggestions = this.didyoumeanprovider.getSuggestionTerms(termset, this.didyoumeansuggestcount, reader);
 			boolean containswildcards = originalQuery.indexOf('*') != -1;
 			if (suggestions.size() == 0 && containswildcards) {
-				String newSuggestionQuery = originalQuery.replaceAll(":\\*?([^*]*)\\*?", ":$1");
+				String newSuggestionQuery = originalQuery.replaceAll("\\*", "");
 				try {
 					rwQuery = parser.parse(newSuggestionQuery);
 					termset = new HashSet<Term>();


### PR DESCRIPTION
Did You mean try to load suggestions without wildcard characters. But there is a problem with Fulltext searchTerms.

```
old: field1:*test* --> field1:test*
new: field1:*test* --> field1:test
```
