### PR TITLE
Fix autocompleter to always use a fresh index reader after the index was

### DIFF
--- a/contentconnector-changelog/src/changelog/entries/2017/01/5865.SUP-3682.bugfix
+++ b/contentconnector-changelog/src/changelog/entries/2017/01/5865.SUP-3682.bugfix
@@ -1,0 +1,4 @@
+The request processor accessing an autocomplete index sometimes started to
+return incorrect results due to index readers that were not reopened after the
+index was modified.
+This has been fixed now.

--- a/contentconnector-lucene-autocomplete/src/main/java/com/gentics/cr/lucene/autocomplete/Autocompleter.java
+++ b/contentconnector-lucene-autocomplete/src/main/java/com/gentics/cr/lucene/autocomplete/Autocompleter.java
@@ -128,7 +128,7 @@ public class Autocompleter implements IEventReceiver, AutocompleteConfigurationK
 
 		IndexAccessor ia = autocompleteLocation.getAccessor();
 		IndexSearcher autoCompleteSearcher = ia.getPrioritizedSearcher();
-		IndexReader autoCompleteReader = ia.getReader();
+		IndexReader autoCompleteReader = autoCompleteSearcher.getIndexReader();
                 
                 // analyze the search term
                 String analyzedTerm = null;
@@ -160,7 +160,6 @@ public class Autocompleter implements IEventReceiver, AutocompleteConfigurationK
 			}
 		} finally {
 			ia.release(autoCompleteSearcher);
-			ia.release(autoCompleteReader);
 		}
 
 		return result;


### PR DESCRIPTION
modified.