### PR TITLE
Raise node.version for fixing sync checking

### DIFF
--- a/contentconnector-changelog/src/changelog/entries/2017/04/5927.bugfix
+++ b/contentconnector-changelog/src/changelog/entries/2017/04/5927.bugfix
@@ -1,0 +1,3 @@
+The node version has been increased to 2.1.2. This node version does not use quartz for scheduling of
+datasource related background jobs. Due to a version conflict of quartz, sometimes the background jobs were
+not scheduled (without any error message), and clearing the caches due to changes in the contentrepository did not work.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.plugin.version>2.4</maven.compiler.plugin.version>
-		<node.version>2.1.0</node.version>
+		<node.version>2.1.2</node.version>
 		<org.apache.tika.version>1.14</org.apache.tika.version>
 		<lucene.version>4.9.0</lucene.version>
 		<surefire.forkcount>8</surefire.forkcount>


### PR DESCRIPTION
The former node.version used quartz 1 to schedule the sync checking job
for datasources. Due to a version conflict (tika bundles quartz 2) the
job was not always scheduled (without logged error message).